### PR TITLE
Fix/upgrade version1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,7 @@ curl -sO https://raw.githubusercontent.com/swanhubx/self-hosted/main/docker/inst
 ## 开始使用
 
 请参考：[教程文档](https://docs.swanlab.cn/guide_cloud/self_host/docker-deploy.html)
+
+## 版本更新
+v1.1（2025.4.27）
+现swanlab相关镜像已更新至v1.1版本，初次使用的用户直接运行`install.sh` 即可享用v1.1版本，原v1版本用户可直接运行`docker/upgrade.sh`对`docker-compose.yaml`进行升级重启。

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -112,7 +112,7 @@ if [[ $docker_not_running -eq 1 ]]; then
     fi
 fi
 
-mkdir swanlab && cd swanlab
+mkdir -p swanlab && cd swanlab
 
 # Select whether to use this configuration
 if [ ! -f .env ] && [ "$SKIP_INPUT" -eq 0 ]; then

--- a/docker/upgrade.sh
+++ b/docker/upgrade.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # update docker-compose.yaml swanlab.* image version
 
@@ -13,8 +13,15 @@ add_replica_env() {
             }
         }
     }
-    ' docker-compose.yaml
+    ' swanlab/docker-compose.yaml
 }
+
+# check docker-compose.yaml exists
+if [ ! -f "swanlab/docker-compose.yaml" ]; then
+    echo "docker-compose.yaml not found, please run install.sh directly"
+    exit 1
+fi
+
 # confirm information
 read -p "Updating the container version will restart docker-compose. Do you agree? [y/N] " confirm
 
@@ -25,13 +32,13 @@ if [[ "$confirm" == [yY] || "$confirm" == [yY][eE][sS] ]]; then
     /^[[:space:]]+image: .*swanlab.*:v1$/ {
         s/(:v1)$/\1.1/
     }
-    ' docker-compose.yaml
+    ' swanlab/docker-compose.yaml
     add_replica_env
     # delete backup
-    rm -f docker-compose.yaml.bak
+    rm -f swanlab/docker-compose.yaml.bak
 
     # restart docker-compose
-    docker-compose pull && docker-compose up -d
+    docker-compose -f swanlab/docker-compose.yaml pull && docker-compose -f swanlab/docker-compose.yaml up -d
     echo "finish update"
 else
     echo "update canceled"

--- a/docker/upgrade.sh
+++ b/docker/upgrade.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# update docker-compose.yaml swanlab.* image version
+
+# add swanlab-server replica database config
+add_replica_env() {
+    sed -i.bak -E '
+    /^[[:space:]]*swanlab-server:/,/^$/ {
+        /environment:/,/^[[:space:]]*- / {
+            /^[[:space:]]*- DATABASE_URL=/ {
+                p
+                s/DATABASE_URL=/DATABASE_URL_REPLICA=/
+            }
+        }
+    }
+    ' docker-compose.yaml
+}
+# confirm information
+read -p "Updating the container version will restart docker-compose. Do you agree? [y/N] " confirm
+
+# check y or Y
+if [[ "$confirm" == [yY] || "$confirm" == [yY][eE][sS] ]]; then
+    echo "begin update"
+    sed -i.bak -E '
+    /^[[:space:]]+image: .*swanlab.*:v1$/ {
+        s/(:v1)$/\1.1/
+    }
+    ' docker-compose.yaml
+    add_replica_env
+    # delete backup
+    rm -f docker-compose.yaml.bak
+
+    # restart docker-compose
+    docker-compose pull && docker-compose up -d
+    echo "finish update"
+else
+    echo "update canceled"
+    exit 1
+fi
+


### PR DESCRIPTION
更新swanlab下的docker-compose中的版本号为v1.1，同时重启docker-compose
使用sed匹配到对应的位置进行增加，同时`DATABASE_URL_REPLICA` 会复制用户原有的`DATABASE_URL` 的密码，保证可以正常重启