### PR TITLE
fix: upgrade script docker compose

### DIFF
--- a/docker/upgrade.sh
+++ b/docker/upgrade.sh
@@ -23,7 +23,7 @@ if [ ! -f "swanlab/docker-compose.yaml" ]; then
 fi
 
 # confirm information
-read -p "Updating the container version will restart docker-compose. Do you agree? [y/N] " confirm
+read -p "Updating the container version will restart docker compose. Do you agree? [y/N] " confirm
 
 # check y or Y
 if [[ "$confirm" == [yY] || "$confirm" == [yY][eE][sS] ]]; then
@@ -38,7 +38,7 @@ if [[ "$confirm" == [yY] || "$confirm" == [yY][eE][sS] ]]; then
     rm -f swanlab/docker-compose.yaml.bak
 
     # restart docker-compose
-    docker-compose -f swanlab/docker-compose.yaml pull && docker-compose -f swanlab/docker-compose.yaml up -d
+    docker compose -f swanlab/docker-compose.yaml pull && docker compose -f swanlab/docker-compose.yaml up -d
     echo "finish update"
 else
     echo "update canceled"


### PR DESCRIPTION
修复在MacOS上`docker-compose`运行报错的问题。

![image](https://github.com/user-attachments/assets/9a4f538c-b8c7-44fd-8658-c162895bb84f)
