### PR TITLE
fix: download csv

### DIFF
--- a/docker/install-dockerhub.sh
+++ b/docker/install-dockerhub.sh
@@ -284,6 +284,7 @@ services:
       - "traefik.http.routers.minio1.rule=PathPrefix(\`/swanlab-public\`)"
       - "traefik.http.routers.minio1.middlewares=minio-host@file"
       - "traefik.http.routers.minio2.rule=PathPrefix(\`/swanlab-private\`)"
+      - "traefik.http.routers.minio2.middlewares=minio-host@file"
     command: server /data --console-address ":9001"
     healthcheck:
       test: ["CMD", "mc", "ready", "local"]

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -284,6 +284,7 @@ services:
       - "traefik.http.routers.minio1.rule=PathPrefix(\`/swanlab-public\`)"
       - "traefik.http.routers.minio1.middlewares=minio-host@file"
       - "traefik.http.routers.minio2.rule=PathPrefix(\`/swanlab-private\`)"
+      - "traefik.http.routers.minio2.middlewares=minio-host@file"
     command: server /data --console-address ":9001"
     healthcheck:
       test: ["CMD", "mc", "ready", "local"]

--- a/docker/upgrade.sh
+++ b/docker/upgrade.sh
@@ -16,6 +16,16 @@ add_replica_env() {
     ' swanlab/docker-compose.yaml
 }
 
+# add missing minio middleware config
+add_minio_middleware() {
+    sed -i.bak '
+    /traefik\.http\.routers\.minio2\.rule=PathPrefix/ {
+        p
+        s/.*/      - "traefik.http.routers.minio2.middlewares=minio-host@file"/
+    }
+    ' swanlab/docker-compose.yaml
+}
+
 # check docker-compose.yaml exists
 if [ ! -f "swanlab/docker-compose.yaml" ]; then
     echo "docker-compose.yaml not found, please run install.sh directly"
@@ -33,10 +43,18 @@ if [[ "$confirm" == [yY] || "$confirm" == [yY][eE][sS] ]]; then
         s/(:v1)$/\1.1/
     }
     ' swanlab/docker-compose.yaml
+
     # add DATABASE_URL_REPLICA
     if ! grep -q "DATABASE_URL_REPLICA" "swanlab/docker-compose.yaml"; then
       add_replica_env
     fi
+
+    # add missing minio middleware if needed
+    if ! grep -q "traefik.http.routers.minio2.middlewares=minio-host@file" "swanlab/docker-compose.yaml"; then
+      echo "add missing minio middleware"
+      add_minio_middleware
+    fi
+
     # swanlab-server:v1.1.2
     sed -i.bak 's/swanlab-server:v1.*/swanlab-server:v1.1.2/g' swanlab/docker-compose.yaml
     # delete backup

--- a/docker/upgrade.sh
+++ b/docker/upgrade.sh
@@ -51,7 +51,6 @@ if [[ "$confirm" == [yY] || "$confirm" == [yY][eE][sS] ]]; then
 
     # add missing minio middleware if needed
     if ! grep -q "traefik.http.routers.minio2.middlewares=minio-host@file" "swanlab/docker-compose.yaml"; then
-      echo "add missing minio middleware"
       add_minio_middleware
     fi
 


### PR DESCRIPTION
修复 csv 无法下载的问题

用户同步该分支后，需要执行更新脚本

```bash
git clone git@github.com:SwanHubX/self-hosted.git
git checkout fix/download-csv
cd self-hosted/docker
./upgrade.sh
```

close https://github.com/SwanHubX/SwanLab-Server/issues/468