### PR TITLE
Update install.sh

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -3,6 +3,7 @@
 [English](./README_EN.md)
 
 > 首先需要确保你的服务器上安装有 [docker](https://docs.docker.com/engine/install/)。如果未安装，可以参考[文档](https://yeasy.gitbook.io/docker_practice/install)，或者使用我们提供的安装脚本 [scripts/install-docker.sh](../scripts/install-docker.sh)。
+> 若你的服务器上未安装Docker Compose插件，可以参考[官方地址](https://github.com/docker/compose/)进行下载安装，或者使用我们提供的安装脚本 [scripts/install-docker-compose.sh](../scripts/install-docker-compose.sh)。
 
 ### 在线部署
 服务器可以联网时，直接执行 `./install.sh` 脚本即可开始部署。部署成功后会看到下面的 **SwanLab** 标志。

--- a/docker/README_EN.md
+++ b/docker/README_EN.md
@@ -2,6 +2,7 @@
 
 [中文](./README.md)
 > First, make sure you have [docker](https://docs.docker.com/engine/install/) installed on your server. If not installed, you can refer to the [documentation](https://docs.docker.com/engine/install/), or use our installation script [scripts/install-docker.sh](../scripts/install-docker.sh).
+> If your server does not have Docker Compose plugin, you can refer to the [documentation](https://github.com/docker/compose/) for downloading and installing. Alternatively, you can use our provided installation script [scripts/install-docker-compose.sh](../scripts/install-docker-compose.sh).
 
 ### Online Deployment
 When the server can be connected to the network, simply execute the `./install-dockerhub.sh` script to start deployment. After successful deployment, you will see the **SwanLab** logo below.

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -53,6 +53,75 @@ fi
 
 echo "🤩 ${bold}Docker is installed, so let's get started.${reset}"
 
+# check if docker-compose is installed
+if ! docker compose version &>/dev/null;  then
+    echo "🧐 ${yellow}Docker Compose not found, start installation...${reset}"
+
+    if [[ "$(uname -s)" == "Linux" ]]; then
+        if [ -f /etc/os-release ]; then
+            source /etc/os-release
+            case "$ID" in
+                ubuntu)
+                    echo "🔧 ${yellow}Adding Docker repository with Aliyun mirror...${reset}"
+                    # add docker repository
+                    sudo mkdir -p /etc/apt/keyrings
+                    curl -fsSL https://mirrors.aliyun.com/docker-ce/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+                    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://mirrors.aliyun.com/docker-ce/linux/ubuntu $VERSION_CODENAME stable" | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+
+                    echo "🔄 ${yellow}Updating package lists...${reset}"
+                    sudo apt-get update -qq || {
+                        echo "❌ ${red}Failed to update package lists${reset}";
+                        exit 1;
+                    }
+
+                    # install docker-compose-plugin
+                    echo "📦 ${yellow}Installing docker-compose-plugin...${reset}"
+                    sudo apt-get install -qq -y docker-compose-plugin || {
+                        echo "❌ ${red}Installation failed, please check network connection${reset}";
+                        exit 1;
+                    }
+                    ;;
+
+                centos)
+                    echo "🔧 ${yellow}Adding Docker repository with Aliyun mirror for CentOS...${reset}"
+                    # add docker repository
+                    sudo yum install -y yum-utils
+                    sudo yum-config-manager --add-repo https://mirrors.aliyun.com/docker-ce/linux/centos/docker-ce.repo
+
+                    echo "🔄 ${yellow}Updating yum cache...${reset}"
+                    sudo yum makecache fast -q || {
+                        echo "❌ ${red}Failed to update yum cache${reset}";
+                        exit 1;
+                    }
+                    #  install docker-compose-plugin
+                    echo "📦 ${yellow}Installing docker-compose-plugin...${reset}"
+                    sudo yum install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin || {
+                        echo "❌ ${red}Installation failed, please check network connection${reset}";
+                        exit 1;
+                    }
+
+                    echo "🚀 ${yellow}Starting Docker service...${reset}"
+                    sudo systemctl enable --now docker
+                    ;;
+
+                *)
+                    echo "❌ ${red}Automatic installation only supported on Ubuntu/CentOS${reset}"
+                    exit 1
+                    ;;
+            esac
+
+            echo "✅ ${green}docker-compose-plugin installed successfully!${reset}"
+        else
+            echo "❌ ${red}Unsupported Linux distribution${reset}"
+            exit 1
+        fi
+    else
+        echo "❌ ${red}macOS/Windows detected: Docker Compose is included in Docker Desktop. Please install Docker Desktop${reset}"
+        exit 1
+    fi
+fi
+
+
 # check if docker daemon is running
 echo "🧐 Checking if Docker is running..."
 docker_not_running=0

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -53,70 +53,14 @@ fi
 
 echo "🤩 ${bold}Docker is installed, so let's get started.${reset}"
 
-# check if docker-compose is installed
+# check if docker compose is installed
 if ! docker compose version &>/dev/null;  then
-    echo "🧐 ${yellow}Docker Compose not found, start installation...${reset}"
+    echo "😰 ${yellow}Docker Compose may not install ${reset}"
 
     if [[ "$(uname -s)" == "Linux" ]]; then
-        if [ -f /etc/os-release ]; then
-            source /etc/os-release
-            case "$ID" in
-                ubuntu)
-                    echo "🔧 ${yellow}Adding Docker repository with Aliyun mirror...${reset}"
-                    # add docker repository
-                    sudo mkdir -p /etc/apt/keyrings
-                    curl -fsSL https://mirrors.aliyun.com/docker-ce/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-                    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://mirrors.aliyun.com/docker-ce/linux/ubuntu $VERSION_CODENAME stable" | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
-
-                    echo "🔄 ${yellow}Updating package lists...${reset}"
-                    sudo apt-get update -qq || {
-                        echo "❌ ${red}Failed to update package lists${reset}";
-                        exit 1;
-                    }
-
-                    # install docker-compose-plugin
-                    echo "📦 ${yellow}Installing docker-compose-plugin...${reset}"
-                    sudo apt-get install -qq -y docker-compose-plugin || {
-                        echo "❌ ${red}Installation failed, please check network connection${reset}";
-                        exit 1;
-                    }
-                    ;;
-
-                centos)
-                    echo "🔧 ${yellow}Adding Docker repository with Aliyun mirror for CentOS...${reset}"
-                    # add docker repository
-                    sudo yum install -y yum-utils
-                    sudo yum-config-manager --add-repo https://mirrors.aliyun.com/docker-ce/linux/centos/docker-ce.repo
-
-                    echo "🔄 ${yellow}Updating yum cache...${reset}"
-                    sudo yum makecache fast -q || {
-                        echo "❌ ${red}Failed to update yum cache${reset}";
-                        exit 1;
-                    }
-                    #  install docker-compose-plugin
-                    echo "📦 ${yellow}Installing docker-compose-plugin...${reset}"
-                    sudo yum install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin || {
-                        echo "❌ ${red}Installation failed, please check network connection${reset}";
-                        exit 1;
-                    }
-
-                    echo "🚀 ${yellow}Starting Docker service...${reset}"
-                    sudo systemctl enable --now docker
-                    ;;
-
-                *)
-                    echo "❌ ${red}Automatic installation only supported on Ubuntu/CentOS${reset}"
-                    exit 1
-                    ;;
-            esac
-
-            echo "✅ ${green}docker-compose-plugin installed successfully!${reset}"
-        else
-            echo "❌ ${red}Unsupported Linux distribution${reset}"
-            exit 1
-        fi
+        echo "😁 ${bold}You can use the install script (${green}install-docker-compose.sh${reset})${bold} located in the scripts directory.${reset}"
     else
-        echo "❌ ${red}macOS/Windows detected: Docker Compose is included in Docker Desktop. Please install Docker Desktop${reset}"
+        echo "🧐 ${red}macOS/Windows detected: Docker Compose is included in Docker Desktop. Please install Docker Desktop${reset}"
         exit 1
     fi
 fi

--- a/scripts/install-docker-compose.sh
+++ b/scripts/install-docker-compose.sh
@@ -1,0 +1,63 @@
+if ! docker compose version &>/dev/null;  then
+    echo "🧐 ${yellow}Docker Compose not found, start installation...${reset}"
+
+    if [[ "$(uname -s)" == "Linux" ]]; then
+        if [ -f /etc/os-release ]; then
+            source /etc/os-release
+            case "$ID" in
+                ubuntu)
+                    echo "🔧 ${yellow}Adding Docker repository with Aliyun mirror...${reset}"
+                    sudo mkdir -p /etc/apt/keyrings
+                    curl -fsSL https://mirrors.aliyun.com/docker-ce/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+                    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://mirrors.aliyun.com/docker-ce/linux/ubuntu $VERSION_CODENAME stable" | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+
+                    echo "🔄 ${yellow}Updating package lists...${reset}"
+                    sudo apt-get update -qq || {
+                        echo "❌ ${red}Failed to update package lists${reset}";
+                        exit 1;
+                    }
+
+                    echo "📦 ${yellow}Installing docker-compose-plugin...${reset}"
+                    sudo apt-get install -qq -y docker-compose-plugin || {
+                        echo "❌ ${red}Installation failed, please check network connection${reset}";
+                        exit 1;
+                    }
+                    ;;
+
+                centos)
+                    echo "🔧 ${yellow}Adding Docker repository with Aliyun mirror for CentOS...${reset}"
+                    sudo yum install -y yum-utils
+                    sudo yum-config-manager --add-repo https://mirrors.aliyun.com/docker-ce/linux/centos/docker-ce.repo
+
+                    echo "🔄 ${yellow}Updating yum cache...${reset}"
+                    sudo yum makecache fast -q || {
+                        echo "❌ ${red}Failed to update yum cache${reset}";
+                        exit 1;
+                    }
+
+                    echo "📦 ${yellow}Installing docker-compose-plugin...${reset}"
+                    sudo yum install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin || {
+                        echo "❌ ${red}Installation failed, please check network connection${reset}";
+                        exit 1;
+                    }
+
+                    echo "🚀 ${yellow}Starting Docker service...${reset}"
+                    sudo systemctl enable --now docker
+                    ;;
+
+                *)
+                    echo "❌ ${red}Automatic installation only supported on Ubuntu/CentOS${reset}"
+                    exit 1
+                    ;;
+            esac
+
+            echo "✅ ${green}docker-compose-plugin installed successfully!${reset}"
+        else
+            echo "❌ ${red}Unsupported Linux distribution${reset}"
+            exit 1
+        fi
+    else
+        echo "❌ ${red}macOS/Windows detected: Docker Compose is included in Docker Desktop. Please install Docker Desktop${reset}"
+        exit 1
+    fi
+fi


### PR DESCRIPTION
### 未安装docker compose插件导致无法运行开发点

#### 1. 直接下载docker compose二进制文件

在最初时，我想直接下载二进制文件在不改变用户docker环境的基础上进行安装，docker官方给出的下载地址（https://github.com/docker/compose/releases/download）
但带来的问题是很多时候用户访问不到GitHub，由此想出可以使用国内镜像来代替GitHub，在尝试过下面三种国内镜像，发现都是访问不通的。
```
"https://mirrors.aliyun.com/docker-toolbox/linux/compose/${latest_version}/docker-compose-$(uname -s)-$(uname -m)"
"https://repo.huaweicloud.com/docker-compose/${latest_version}/docker-compose-$(uname -s)-$(uname -m)"
"https://ghproxy.com/https://github.com/docker/compose/releases/download/${latest_version}/docker-compose-$(uname -s)-$(uname -m)"  # 在GitHub前增加国内代理
```
再进一步尝试点进阿里云镜像的官网，发现`https://mirrors.aliyun.com/docker-toolbox/linux/compose/`只在2018年上传过一次，而且都是x86的架构，无法满足用户不同架构机器的需求，阿里云官方推荐使用`docker-ce`来安装。

再继续查找资料后，在https://blog.csdn.net/lin1214000999/article/details/122081039 的2025年的博客中提到新的镜像地址，`https://get.daocloud.io/docker/compose/releases/download` ，但是该网站无法访问到。可能是现在升级到V2了，原docker-compose已经停止维护了。**此方法受阻**

#### 2. 添加 Docker 官方仓库（使用阿里云镜像加速），直接下载插件

在调查无果后，就直接添加新的仓库,然后直接安装插件，此举运行成功。
```
# 添加 Docker 官方仓库（使用阿里云镜像加速）
sudo add-apt-repository "deb [arch=amd64] https://mirrors.aliyun.com/docker-ce/linux/ubuntu $(lsb_release -cs) stable"
sudo apt update
# 安装插件
sudo apt install docker-compose-plugin
```
centos也是同理，添加阿里云Docker CE镜像源，安装插件。

Fix #22