### PR TITLE
fix(build): wsl check docker running

### DIFF
--- a/docker/install.sh
+++ b/docker/install.sh
@@ -68,19 +68,10 @@ fi
 
 # check if docker daemon is running
 echo "🧐 Checking if Docker is running..."
-docker_not_running=0
+docker_not_running=1
 
-# Different platform methods
-if [[ "$(uname -s)" == "Linux" ]]; then
-    # Linux use systemctl to check
-    if ! systemctl is-active docker >/dev/null 2>&1; then
-        docker_not_running=1
-    fi
-else
-    # macOs/Windows use docker info to check
-    if ! docker info >/dev/null 2>&1; then
-        docker_not_running=1
-    fi
+if docker info >/dev/null 2>&1; then
+    docker_not_running=0
 fi
 
 if [[ $docker_not_running -eq 1 ]]; then


### PR DESCRIPTION
## 修复在**WSL**上, 显示`docker daemon`未运行的问题

修改为: 通过用`docker info`命令是否能执行, 判断`docker daemon`是否正常, 如下:

```bash
# check if docker daemon is running
echo "🧐 Checking if Docker is running..."
docker_not_running=1

if docker info >/dev/null 2>&1; then
    docker_not_running=0
fi
```