### PR TITLE
Feature/add environment args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ playground
 .key
 data
 .env
-docker-compose.yaml

--- a/docker/README.md
+++ b/docker/README.md
@@ -82,4 +82,4 @@ swanlab-traefik      ccr.ccs.tencentyun.com/self-hosted/traefik:v3.0            
 
 ### 升级
 
-执行 `./upgrade.sh` 可以进行无缝升级。
+执行 `./upgrade.sh` 可以进行无缝升级。可使用`./upgrade.sh file_path`来进行升级，`file_path`为`docker-compose.yaml`文件路径。，默认为`swanlab/docker-compose.yaml`

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,218 @@
+networks:
+  swanlab-net:
+    name: swanlab-net
+
+volumes:
+  swanlab-house:
+    name: swanlab-house
+  fluent-bit:
+    name: fluent-bit
+
+x-common: &common
+  networks:
+    - swanlab-net
+  restart: unless-stopped
+  logging:
+    options:
+      max-size: 50m
+      max-file: "3"
+
+services:
+  # Gateway
+  traefik:
+    <<: *common
+    image: ccr.ccs.tencentyun.com/self-hosted/traefik:v3.0
+    container_name: swanlab-traefik
+    ports:
+      - "8000:80"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "0.0.0.0:8080/ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+  # Databases
+  postgres:
+    <<: *common
+    image: ccr.ccs.tencentyun.com/self-hosted/postgres:16.1
+    container_name: swanlab-postgres
+    environment:
+      TZ: UTC
+      POSTGRES_USER: swanlab
+      POSTGRES_PASSWORD: swanlab-postgres
+      POSTGRES_DB: app
+    volumes:
+      - ./data/postgres/data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  redis:
+    <<: *common
+    image: ccr.ccs.tencentyun.com/self-hosted/redis-stack-server:7.2.0-v15
+    container_name: swanlab-redis
+    volumes:
+      - ./data/redis:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+  clickhouse:
+    <<: *common
+    image: ccr.ccs.tencentyun.com/self-hosted/clickhouse:24.3
+    container_name: swanlab-clickhouse
+    volumes:
+      - ./data/clickhouse:/var/lib/clickhouse/
+    environment:
+      TZ: UTC
+      CLICKHOUSE_USER: swanlab
+      CLICKHOUSE_PASSWORD: swanlab-clickhouse
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "0.0.0.0:8123/ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+  logrotate:
+    <<: *common
+    image: ccr.ccs.tencentyun.com/self-hosted/logrotate:v1
+    container_name: swanlab-logrotate
+    volumes:
+      - swanlab-house:/data
+    environment:
+      LOGS_DIRECTORIES: "/data"
+      LOGROTATE_COPIES: 25
+      LOGROTATE_SIZE: "25M"
+      LOGROTATE_CRONSCHEDULE: "*/20 * * * * *"
+      LOGROTATE_INTERVAL: daily
+    labels:
+      - "traefik.enable=false"
+  fluent-bit:
+    <<: *common
+    image: ccr.ccs.tencentyun.com/self-hosted/fluent-bit:3.0
+    container_name: swanlab-fluentbit
+    command: ["fluent-bit/bin/fluent-bit", "-c", "/conf/fluent-bit.conf"]
+    volumes:
+      - fluent-bit:/data
+      - swanlab-house:/metrics
+    environment:
+      LOG_PATH: /metrics/*.log
+      CLICKHOUSE_HOST: clickhouse
+      CLICKHOUSE_PORT: 8123
+      CLICKHOUSE_USER: swanlab
+      CLICKHOUSE_PASS: swanlab-clickhouse
+  minio:
+    <<: *common
+    image: ccr.ccs.tencentyun.com/self-hosted/minio:RELEASE.2025-02-28T09-55-16Z
+    container_name: swanlab-minio
+    volumes:
+      - ./data/minio:/data
+    environment:
+      MINIO_ROOT_USER: swanlab
+      MINIO_ROOT_PASSWORD: swanlab-minio
+    labels:
+      - "traefik.http.services.minio.loadbalancer.server.port=9000"
+      - "traefik.http.routers.minio1.rule=PathPrefix(`/swanlab-public`)"
+      - "traefik.http.routers.minio1.middlewares=minio-host@file"
+      - "traefik.http.routers.minio2.rule=PathPrefix(`/swanlab-private`)"
+      - "traefik.http.routers.minio2.middlewares=minio-host@file"
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+  create-buckets:
+    image: ccr.ccs.tencentyun.com/self-hosted/minio-mc:RELEASE.2025-04-08T15-39-49Z
+    container_name: swanlab-minio-mc
+    networks:
+      - swanlab-net
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+        mc alias set myminio http://minio:9000 swanlab swanlab-minio
+        # private bucket
+        mc mb --ignore-existing myminio/swanlab-private
+        mc anonymous set private myminio/swanlab-private
+        # public bucket
+        mc mb --ignore-existing myminio/swanlab-public
+        mc anonymous set public myminio/swanlab-public
+      "
+  # swanlab services
+  swanlab-server:
+    <<: *common
+    image: swanlab/swanlab-server:v1.2
+    container_name: swanlab-server
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      - DATABASE_URL=postgresql://swanlab:swanlab-postgres@postgres:5432/app?schema=public
+      - DATABASE_URL_REPLICA=postgresql://swanlab:swanlab-postgres@postgres:5432/app?schema=public
+      - REDIS_URL=redis://default@redis:6379
+      - SERVER_PREFIX=/api
+      - ACCESS_KEY=swanlab
+      - SECRET_KEY=swanlab-minio
+      - VERSION=1.2.0
+    labels:
+      - "traefik.http.routers.swanlab-server.rule=PathPrefix(`/api`)"
+      - "traefik.http.routers.swanlab-server.middlewares=preprocess@file"
+    command: bash -c "npx prisma migrate deploy && node migrate.js && pm2-runtime app.js"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "0.0.0.0:3000/api/"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+  swanlab-house:
+    <<: *common
+    image: ccr.ccs.tencentyun.com/self-hosted/swanlab-house:v1.2
+    container_name: swanlab-house
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      - SH_API_PREFIX=/api/house
+      - SH_LOG_PATH=/data/metrics.log
+      - SH_DATABASE_URL=tcp://swanlab:swanlab-clickhouse@clickhouse:9000/app
+      - SH_SERVER_URL=http://swanlab-server:3000/api
+      - SH_MINIO_SECRET_ID=swanlab
+      - SH_MINIO_SECRET_KEY=swanlab-minio
+      - SH_DISTRIBUTED_ENABLE=true
+      - SH_REDIS_URL=redis://default@redis:6379
+    labels:
+      - "traefik.http.routers.swanlab-house.rule=PathPrefix(`/api/house`) || PathPrefix(`/api/internal`)"
+      - "traefik.http.routers.swanlab-house.middlewares=preprocess@file"
+    volumes:
+      - swanlab-house:/data
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "0.0.0.0:3000/api/house/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+  swanlab-cloud:
+    <<: *common
+    image: ccr.ccs.tencentyun.com/self-hosted/swanlab-cloud:v1.2
+    container_name: swanlab-cloud
+    depends_on:
+      swanlab-server:
+        condition: service_healthy
+  swanlab-next:
+    <<: *common
+    image: ccr.ccs.tencentyun.com/self-hosted/swanlab-next:v1.2
+    container_name: swanlab-next
+    depends_on:
+      swanlab-server:
+        condition: service_healthy
+    environment:
+      - NEXT_CLOUD_URL=http://swanlab-cloud:80
+    labels:
+      - "traefik.http.routers.swanlab-next.rule=PathPrefix(`/`)"

--- a/docker/install-dockerhub.sh
+++ b/docker/install-dockerhub.sh
@@ -312,7 +312,7 @@ services:
   # swanlab services
   swanlab-server:
     <<: *common
-    image: swanlab/swanlab-server:v1.1.1
+    image: swanlab/swanlab-server:v1.2
     container_name: swanlab-server
     depends_on:
       postgres:
@@ -326,10 +326,11 @@ services:
       - SERVER_PREFIX=/api
       - ACCESS_KEY=swanlab
       - SECRET_KEY=${MINIO_ROOT_PASSWORD}
+      - VERSION=1.2.0
     labels:
       - "traefik.http.routers.swanlab-server.rule=PathPrefix(\`/api\`)"
       - "traefik.http.routers.swanlab-server.middlewares=preprocess@file"
-    command: bash -c "npx prisma migrate deploy && pm2-runtime app.js"
+    command: bash -c "npx prisma migrate deploy && node migrate.js && pm2-runtime app.js"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "0.0.0.0:3000/api/"]
       interval: 10s
@@ -337,7 +338,7 @@ services:
       retries: 3
   swanlab-house:
     <<: *common
-    image: swanlab/swanlab-house:v1.1
+    image: swanlab/swanlab-house:v1.2
     container_name: swanlab-house
     depends_on:
       clickhouse:
@@ -351,6 +352,8 @@ services:
       - SH_SERVER_URL=http://swanlab-server:3000/api
       - SH_MINIO_SECRET_ID=swanlab
       - SH_MINIO_SECRET_KEY=${MINIO_ROOT_PASSWORD}
+      - SH_DISTRIBUTED_ENABLE=true
+      - SH_REDIS_URL=redis://default@redis:6379
     labels:
       - "traefik.http.routers.swanlab-house.rule=PathPrefix(\`/api/house\`) || PathPrefix(\`/api/internal\`)"
       - "traefik.http.routers.swanlab-house.middlewares=preprocess@file"
@@ -363,14 +366,14 @@ services:
       retries: 3
   swanlab-cloud:
     <<: *common
-    image: swanlab/swanlab-cloud:v1.1
+    image: swanlab/swanlab-cloud:v1.2
     container_name: swanlab-cloud
     depends_on:
       swanlab-server:
         condition: service_healthy
   swanlab-next:
     <<: *common
-    image: swanlab/swanlab-next:v1.1
+    image: swanlab/swanlab-next:v1.2
     container_name: swanlab-next
     depends_on:
       swanlab-server:
@@ -392,7 +395,7 @@ echo "  \___ \ \ /\ / / _\` | '_ \| |    / _\` | '_ \ ";
 echo "  ____) \ V  V / (_| | | | | |___| (_| | |_) |";
 echo " |_____/ \_/\_/ \__,_|_| |_|______\__,_|_.__/ ";
 echo "                                              ";
-echo " Self-Hosted Docker v1.1 - @SwanLab"
+echo " Self-Hosted Docker v1.2 - @SwanLab"
 echo -e "${reset}"
 echo "🎉 Wow, the installation is complete. Everything is perfect."
 echo "🥰 Congratulations, self-hosted SwanLab can be accessed using ${green}{IP}:${EXPOSE_PORT}${reset}"

--- a/docker/upgrade.sh
+++ b/docker/upgrade.sh
@@ -127,7 +127,7 @@ if [[ "$confirm" == [yY] || "$confirm" == [yY][eE][sS] ]]; then
     fi
 
     # delete backup
-    # rm -f "${COMPOSE_FILE}.bak"
+    rm -f "${COMPOSE_FILE}.bak"
 
     # add new environment variable for containers config, it only can be added once and can not be update existing
     # add swanlab-house environment variable
@@ -142,8 +142,8 @@ if [[ "$confirm" == [yY] || "$confirm" == [yY][eE][sS] ]]; then
       add_environment_var "swanlab-server" "VERSION=1.2.0"
     fi
 
-    # # restart docker-compose
-    # docker compose -f swanlab/docker-compose.yaml up -d
+    # restart docker-compose
+    docker compose -f swanlab/docker-compose.yaml up -d
     echo "finish update"
 else
     echo "update canceled"


### PR DESCRIPTION
- `awk` 是一个功能强大的文本处理工具，广泛用于 Linux/Unix 系统中。它以结构化的方式处理文本数据，支持模式匹配、字段提取、条件判断、循环控制等操作。在主流的Linux系统中都会进行预装，能够快速对文本进行筛选。
- `add_new_var` 函数可以通用处理需要给服务增加某个键下的变量的情况。例如`swanlab-house`服务需要在`environment`下增加`SH_REDIS_URL=redis://default@redis:6379`环境变量，那么就可以使用`add_new_var`函数，参数为`service name,label key,new variable`,参数1表示哪个服务，参数2表示在`environment`下的位置，参数3表示变量值。这样我们就可以将原来脚本中的`add_minio_middleware`函数替换为`add_new_var`函数，增加通用性
- `update_version`函数 用来修改所有`swanlab-*` 的版本号，只需要每次传入版本号即可，会将`docker-compose.yaml`中的所有`swanlab-*`的版本号都修改为传入的版本号。
- 用户运行`upgrade`脚本可以指定`docker-compose.yaml`文件的路径，不传的话默认为`swanlab/docker-compose.yaml`。