### PR TITLE
Fix/upgrade and install

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -49,6 +49,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    labels:
+      - "traefik.enable=false"
   redis:
     <<: *common
     image: ccr.ccs.tencentyun.com/self-hosted/redis-stack-server:7.2.0-v15
@@ -60,6 +62,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+    labels:
+      - "traefik.enable=false"
   clickhouse:
     <<: *common
     image: ccr.ccs.tencentyun.com/self-hosted/clickhouse:24.3
@@ -76,6 +80,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+    labels:
+      - "traefik.enable=false"
   logrotate:
     <<: *common
     image: ccr.ccs.tencentyun.com/self-hosted/logrotate:v1
@@ -104,6 +110,8 @@ services:
       CLICKHOUSE_PORT: 8123
       CLICKHOUSE_USER: swanlab
       CLICKHOUSE_PASS: swanlab-clickhouse
+    labels:
+      - "traefik.enable=false"
   minio:
     <<: *common
     image: ccr.ccs.tencentyun.com/self-hosted/minio:RELEASE.2025-02-28T09-55-16Z
@@ -145,6 +153,8 @@ services:
         mc mb --ignore-existing myminio/swanlab-public
         mc anonymous set public myminio/swanlab-public
       "
+    labels:
+      - "traefik.enable=false"
   # swanlab services
   swanlab-server:
     <<: *common
@@ -164,6 +174,7 @@ services:
       - SECRET_KEY=swanlab-minio
       - VERSION=1.3.0
     labels:
+      - "traefik.http.services.swanlab-server.loadbalancer.server.port=3000"
       - "traefik.http.routers.swanlab-server.rule=PathPrefix(`/api`)"
       - "traefik.http.routers.swanlab-server.middlewares=preprocess@file"
     command: bash -c "npx prisma migrate deploy && node migrate.js && pm2-runtime app.js"
@@ -191,6 +202,7 @@ services:
       - SH_DISTRIBUTED_ENABLE=true
       - SH_REDIS_URL=redis://default@redis:6379
     labels:
+      - "traefik.http.services.swanlab-house.loadbalancer.server.port=3000"
       - "traefik.http.routers.swanlab-house.rule=PathPrefix(`/api/house`) || PathPrefix(`/api/internal`)"
       - "traefik.http.routers.swanlab-house.middlewares=preprocess@file"
     volumes:
@@ -207,6 +219,8 @@ services:
     depends_on:
       swanlab-server:
         condition: service_healthy
+    labels:
+      - "traefik.enable=false"
   swanlab-next:
     <<: *common
     image: ccr.ccs.tencentyun.com/self-hosted/swanlab-next:v1.2
@@ -217,4 +231,5 @@ services:
     environment:
       - NEXT_CLOUD_URL=http://swanlab-cloud:80
     labels:
+      - "traefik.http.services.swanlab-next.loadbalancer.server.port=3000"
       - "traefik.http.routers.swanlab-next.rule=PathPrefix(`/`)"

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -219,6 +219,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    labels:
+      - "traefik.enable=false"
   redis:
     <<: *common
     image: ccr.ccs.tencentyun.com/self-hosted/redis-stack-server:7.2.0-v15
@@ -230,6 +232,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+    labels:
+      - "traefik.enable=false"
   clickhouse:
     <<: *common
     image: ccr.ccs.tencentyun.com/self-hosted/clickhouse:24.3
@@ -246,6 +250,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+    labels:
+      - "traefik.enable=false"
   logrotate:
     <<: *common
     image: ccr.ccs.tencentyun.com/self-hosted/logrotate:v1
@@ -274,6 +280,8 @@ services:
       CLICKHOUSE_PORT: 8123
       CLICKHOUSE_USER: swanlab
       CLICKHOUSE_PASS: ${CLICKHOUSE_PASSWORD}
+    labels:
+      - "traefik.enable=false"
   minio:
     <<: *common
     image: ccr.ccs.tencentyun.com/self-hosted/minio:RELEASE.2025-02-28T09-55-16Z
@@ -315,6 +323,8 @@ services:
         mc mb --ignore-existing myminio/swanlab-public
         mc anonymous set public myminio/swanlab-public
       "
+    labels:
+      - "traefik.enable=false"
   # swanlab services
   swanlab-server:
     <<: *common
@@ -334,6 +344,7 @@ services:
       - SECRET_KEY=${MINIO_ROOT_PASSWORD}
       - VERSION=1.3.0
     labels:
+      - "traefik.http.services.swanlab-server.loadbalancer.server.port=3000"
       - "traefik.http.routers.swanlab-server.rule=PathPrefix(\`/api\`)"
       - "traefik.http.routers.swanlab-server.middlewares=preprocess@file"
     command: bash -c "npx prisma migrate deploy && node migrate.js && pm2-runtime app.js"
@@ -361,6 +372,7 @@ services:
       - SH_DISTRIBUTED_ENABLE=true
       - SH_REDIS_URL=redis://default@redis:6379
     labels:
+      - "traefik.http.services.swanlab-house.loadbalancer.server.port=3000"
       - "traefik.http.routers.swanlab-house.rule=PathPrefix(\`/api/house\`) || PathPrefix(\`/api/internal\`)"
       - "traefik.http.routers.swanlab-house.middlewares=preprocess@file"
     volumes:
@@ -377,6 +389,8 @@ services:
     depends_on:
       swanlab-server:
         condition: service_healthy
+    labels:
+      - "traefik.enable=false"
   swanlab-next:
     <<: *common
     image: ccr.ccs.tencentyun.com/self-hosted/swanlab-next:v1.2
@@ -387,6 +401,7 @@ services:
     environment:
       - NEXT_CLOUD_URL=http://swanlab-cloud:80
     labels:
+      - "traefik.http.services.swanlab-next.loadbalancer.server.port=3000"
       - "traefik.http.routers.swanlab-next.rule=PathPrefix(\`/\`)"
 EOF
 

--- a/docker/upgrade.sh
+++ b/docker/upgrade.sh
@@ -17,37 +17,20 @@ add_replica_env() {
     ' "$COMPOSE_FILE"
 }
 
+# 2. 为指定 service 添加 traefik.enable=false
 add_traefik_disable_label() {
-    local service="$1"
-    sed -i.bak -E "/^[[:space:]]*${service}:/,/^[[:space:]]*[a-zA-Z0-9_-]+:/ {
-      /labels:/ {
-        a\
-          \ \ \ \ - \"traefik.enable=false\"
-        b
-      }
-      /^(  )+[a-zA-Z_]+:/ {
-        i\
-          \ \ \ \ labels:\n        - \"traefik.enable=false\"
-        b
-      }
-    }" "$COMPOSE_FILE"
+  local service=$1
+  sed -i.bak -E '
+  ' "$COMPOSE_FILE"
 }
 
+
+# 3. 为指定 service 添加 traefik 端口 label
 add_traefik_port_label() {
-    local service="$1"
-    local port="$2"
-    sed -i.bak -E "/^[[:space:]]*${service}:/,/^[[:space:]]*[a-zA-Z0-9_-]+:/ {
-      /labels:/ {
-        a\
-          \ \ \ \ - \"traefik.http.services.${service}.loadbalancer.server.port=${port}\"
-        b
-      }
-      /^(  )+[a-zA-Z_]+:/ {
-        i\
-          \ \ \ \ labels:\n        - \"traefik.http.services.${service}.loadbalancer.server.port=${port}\"
-        b
-      }
-    }" "$COMPOSE_FILE"
+  local service=$1
+  local port=$2
+  sed -i.bak -E '
+  ' "$COMPOSE_FILE"
 }
 
 
@@ -171,6 +154,9 @@ if [[ "$confirm" == [yY] || "$confirm" == [yY][eE][sS] ]]; then
       add_traefik_disable_label "postgres"
       add_traefik_disable_label "redis"
       add_traefik_disable_label "clickhouse"
+      add_traefik_disable_label "fluent-bit"
+      add_traefik_disable_label "create-buckets"
+      add_traefik_disable_label "swanlab-cloud"
     fi
 
     # update swanlab-server command
@@ -199,7 +185,7 @@ if [[ "$confirm" == [yY] || "$confirm" == [yY][eE][sS] ]]; then
       add_new_var "minio" "labels" "\"traefik.http.routers.minio2.middlewares=minio-host@file\""
     fi
     # restart docker-compose
-    docker compose -f swanlab/docker-compose.yaml up -d
+    # docker compose -f swanlab/docker-compose.yaml up -d
     echo "finish update"
 else
     echo "update canceled"


### PR DESCRIPTION
补充为指定 `service` 添加 `traefik.enable=false`函数`add_traefik_disable_label()`和
为指定` service` 添加 `traefik` 端口 `label`函数`add_traefik_port_label()`

`add_traefik_port_label()`函数复用了之前的`add_new_var()`，相当于在`label`标签下增加了一个值

`add_traefik_disable_label()`函数在`image`子块后增加
```
labels:
      - "traefik.enable=false"
```
这样实现起来比较省事，不用再繁琐的判断服务块在哪里才结束。