### PR TITLE
fix upgrade.sh and install.sh

### DIFF
--- a/docker/install-dockerhub.sh
+++ b/docker/install-dockerhub.sh
@@ -208,6 +208,8 @@ services:
       POSTGRES_USER: swanlab
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: app
+    labels:
+      - "traefik.enable=false"
     volumes:
       - ${DATA_PATH}/postgres/data:/var/lib/postgresql/data
     healthcheck:
@@ -221,6 +223,8 @@ services:
     container_name: swanlab-redis
     volumes:
       - ${DATA_PATH}/redis:/data
+    labels:
+      - "traefik.enable=false"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
@@ -237,6 +241,8 @@ services:
       CLICKHOUSE_USER: swanlab
       CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+    labels:
+      - "traefik.enable=false"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "0.0.0.0:8123/ping"]
       interval: 10s
@@ -270,6 +276,8 @@ services:
       CLICKHOUSE_PORT: 8123
       CLICKHOUSE_USER: swanlab
       CLICKHOUSE_PASS: ${CLICKHOUSE_PASSWORD}
+    labels:
+      - "traefik.enable=false"
   minio:
     <<: *common
     image: swanlab/minio:RELEASE.2025-02-28T09-55-16Z
@@ -301,6 +309,8 @@ services:
     depends_on:
       minio:
         condition: service_healthy
+    labels:
+      - "traefik.enable=false"
     entrypoint: >
       /bin/sh -c "
         mc alias set myminio http://minio:9000 swanlab ${MINIO_ROOT_PASSWORD}
@@ -330,6 +340,7 @@ services:
       - SECRET_KEY=${MINIO_ROOT_PASSWORD}
       - VERSION=1.3.0
     labels:
+      - "traefik.http.services.swanlab-server.loadbalancer.server.port=3000"
       - "traefik.http.routers.swanlab-server.rule=PathPrefix(\`/api\`)"
       - "traefik.http.routers.swanlab-server.middlewares=preprocess@file"
     command: bash -c "npx prisma migrate deploy && node migrate.js && pm2-runtime app.js"
@@ -357,6 +368,7 @@ services:
       - SH_DISTRIBUTED_ENABLE=true
       - SH_REDIS_URL=redis://default@redis:6379
     labels:
+      - "traefik.http.services.swanlab-house.loadbalancer.server.port=3000"
       - "traefik.http.routers.swanlab-house.rule=PathPrefix(\`/api/house\`) || PathPrefix(\`/api/internal\`)"
       - "traefik.http.routers.swanlab-house.middlewares=preprocess@file"
     volumes:
@@ -373,6 +385,8 @@ services:
     depends_on:
       swanlab-server:
         condition: service_healthy
+    labels:
+      - "traefik.enable=false"
   swanlab-next:
     <<: *common
     image: swanlab/swanlab-next:v1.2
@@ -383,6 +397,7 @@ services:
     environment:
       - NEXT_CLOUD_URL=http://swanlab-cloud:80
     labels:
+      - "traefik.http.services.swanlab-next.loadbalancer.server.port=3000"
       - "traefik.http.routers.swanlab-next.rule=PathPrefix(\`/\`)"
 EOF
 

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -219,6 +219,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    labels:
+      - "traefik.enable=false"
   redis:
     <<: *common
     image: ccr.ccs.tencentyun.com/self-hosted/redis-stack-server:7.2.0-v15
@@ -230,6 +232,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+    labels:
+      - "traefik.enable=false"
   clickhouse:
     <<: *common
     image: ccr.ccs.tencentyun.com/self-hosted/clickhouse:24.3
@@ -246,6 +250,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+    labels:
+      - "traefik.enable=false"
   logrotate:
     <<: *common
     image: ccr.ccs.tencentyun.com/self-hosted/logrotate:v1
@@ -274,6 +280,8 @@ services:
       CLICKHOUSE_PORT: 8123
       CLICKHOUSE_USER: swanlab
       CLICKHOUSE_PASS: ${CLICKHOUSE_PASSWORD}
+    labels:
+      - "traefik.enable=false"
   minio:
     <<: *common
     image: ccr.ccs.tencentyun.com/self-hosted/minio:RELEASE.2025-02-28T09-55-16Z
@@ -315,6 +323,8 @@ services:
         mc mb --ignore-existing myminio/swanlab-public
         mc anonymous set public myminio/swanlab-public
       "
+    labels:
+      - "traefik.enable=false"
   # swanlab services
   swanlab-server:
     <<: *common
@@ -334,6 +344,7 @@ services:
       - SECRET_KEY=${MINIO_ROOT_PASSWORD}
       - VERSION=1.3.0
     labels:
+      - "traefik.http.services.swanlab-server.loadbalancer.server.port=3000"
       - "traefik.http.routers.swanlab-server.rule=PathPrefix(\`/api\`)"
       - "traefik.http.routers.swanlab-server.middlewares=preprocess@file"
     command: bash -c "npx prisma migrate deploy && node migrate.js && pm2-runtime app.js"
@@ -361,6 +372,7 @@ services:
       - SH_DISTRIBUTED_ENABLE=true
       - SH_REDIS_URL=redis://default@redis:6379
     labels:
+      - "traefik.http.services.swanlab-house.loadbalancer.server.port=3000"
       - "traefik.http.routers.swanlab-house.rule=PathPrefix(\`/api/house\`) || PathPrefix(\`/api/internal\`)"
       - "traefik.http.routers.swanlab-house.middlewares=preprocess@file"
     volumes:
@@ -377,6 +389,8 @@ services:
     depends_on:
       swanlab-server:
         condition: service_healthy
+    labels:
+      - "traefik.enable=false"
   swanlab-next:
     <<: *common
     image: ccr.ccs.tencentyun.com/self-hosted/swanlab-next:v1.2
@@ -387,6 +401,7 @@ services:
     environment:
       - NEXT_CLOUD_URL=http://swanlab-cloud:80
     labels:
+      - "traefik.http.services.swanlab-next.loadbalancer.server.port=3000"
       - "traefik.http.routers.swanlab-next.rule=PathPrefix(\`/\`)"
 EOF
 


### PR DESCRIPTION
补充为指定 `service` 添加 `traefik.enable=false`函数`add_traefik_disable_label()`和
为指定` service` 添加 `traefik` 端口 `label`函数`add_traefik_port_label()`

`add_traefik_port_label()`函数复用了之前的`add_new_var()`，相当于在`label`标签下增加了一个值

`add_traefik_disable_label()`函数在`image`子块后增加
```
labels:
      - "traefik.enable=false"
```
这样实现起来比较省事，不用再繁琐的判断服务块在哪里才结束。