### PR TITLE
fix: support rootless docker socket in install scripts

### DIFF
--- a/docker/install-dockerhub.sh
+++ b/docker/install-dockerhub.sh
@@ -105,15 +105,16 @@ fi
 
 resolve_docker_socket_path() {
     local docker_host="${DOCKER_HOST:-}"
+    local rootless_socket="/run/user/$(id -u)/docker.sock"
 
-    if [ -z "$docker_host" ] && [[ "$(uname -s)" == "Linux" ]]; then
+    if [ -z "$docker_host" ]; then
         docker_host=$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null || true)
     fi
 
     if [[ "$docker_host" == unix://* ]]; then
         DOCKER_SOCKET_PATH="${docker_host#unix://}"
-    elif [[ "$(uname -s)" == "Linux" && -S "/run/user/$(id -u)/docker.sock" && ! -S "/var/run/docker.sock" ]]; then
-        DOCKER_SOCKET_PATH="/run/user/$(id -u)/docker.sock"
+    elif [[ -S "$rootless_socket" ]]; then
+        DOCKER_SOCKET_PATH="$rootless_socket"
     else
         DOCKER_SOCKET_PATH="/var/run/docker.sock"
     fi

--- a/docker/install-dockerhub.sh
+++ b/docker/install-dockerhub.sh
@@ -19,7 +19,7 @@ EXPOSE_PORT=8000
 # shell flag: -s, if -s is added, no manual input is required
 SKIP_INPUT=0
 
-while getopts ":d:p:" opt; do
+while getopts ":d:p:s" opt; do
   case ${opt} in
     d )
       DATA_PATH="$OPTARG"
@@ -55,19 +55,10 @@ echo "🤩 ${bold}Docker is installed, so let's get started.${reset}"
 
 # check if docker daemon is running
 echo "🧐 Checking if Docker is running..."
-docker_not_running=0
+docker_not_running=1
 
-# Different platform methods
-if [[ "$(uname -s)" == "Linux" ]]; then
-    # Linux use systemctl to check
-    if ! systemctl is-active docker >/dev/null 2>&1; then
-        docker_not_running=1
-    fi
-else
-    # macOs/Windows use docker info to check
-    if ! docker info >/dev/null 2>&1; then
-        docker_not_running=1
-    fi
+if docker info >/dev/null 2>&1; then
+    docker_not_running=0
 fi
 
 if [[ $docker_not_running -eq 1 ]]; then
@@ -111,6 +102,30 @@ if [[ $docker_not_running -eq 1 ]]; then
         exit 1
     fi
 fi
+
+resolve_docker_socket_path() {
+    local docker_host="${DOCKER_HOST:-}"
+
+    if [ -z "$docker_host" ] && [[ "$(uname -s)" == "Linux" ]]; then
+        docker_host=$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null || true)
+    fi
+
+    if [[ "$docker_host" == unix://* ]]; then
+        DOCKER_SOCKET_PATH="${docker_host#unix://}"
+    elif [[ "$(uname -s)" == "Linux" && -S "/run/user/$(id -u)/docker.sock" && ! -S "/var/run/docker.sock" ]]; then
+        DOCKER_SOCKET_PATH="/run/user/$(id -u)/docker.sock"
+    else
+        DOCKER_SOCKET_PATH="/var/run/docker.sock"
+    fi
+
+    if [ ! -S "$DOCKER_SOCKET_PATH" ]; then
+        echo "⚠️ ${yellow}Docker socket not found at ${DOCKER_SOCKET_PATH}. Traefik may fail to access Docker events.${reset}"
+    else
+        echo "🐳 Using Docker socket: ${green}${DOCKER_SOCKET_PATH}${reset}"
+    fi
+}
+
+resolve_docker_socket_path
 
 mkdir -p swanlab && cd swanlab
 
@@ -192,7 +207,7 @@ services:
     ports:
       - "${EXPOSE_PORT}:80"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - ${DOCKER_SOCKET_PATH}:/var/run/docker.sock
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "0.0.0.0:8080/ping"]
       interval: 10s

--- a/docker/install-nowsl.sh
+++ b/docker/install-nowsl.sh
@@ -118,15 +118,16 @@ fi
 
 resolve_docker_socket_path() {
     local docker_host="${DOCKER_HOST:-}"
+    local rootless_socket="/run/user/$(id -u)/docker.sock"
 
-    if [ -z "$docker_host" ] && [[ "$(uname -s)" == "Linux" ]]; then
+    if [ -z "$docker_host" ]; then
         docker_host=$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null || true)
     fi
 
     if [[ "$docker_host" == unix://* ]]; then
         DOCKER_SOCKET_PATH="${docker_host#unix://}"
-    elif [[ "$(uname -s)" == "Linux" && -S "/run/user/$(id -u)/docker.sock" && ! -S "/var/run/docker.sock" ]]; then
-        DOCKER_SOCKET_PATH="/run/user/$(id -u)/docker.sock"
+    elif [[ -S "$rootless_socket" ]]; then
+        DOCKER_SOCKET_PATH="$rootless_socket"
     else
         DOCKER_SOCKET_PATH="/var/run/docker.sock"
     fi

--- a/docker/install-nowsl.sh
+++ b/docker/install-nowsl.sh
@@ -19,7 +19,7 @@ EXPOSE_PORT=8000
 # shell flag: -s, if -s is added, no manual input is required
 SKIP_INPUT=0
 
-while getopts ":d:p:" opt; do
+while getopts ":d:p:s" opt; do
   case ${opt} in
     d )
       DATA_PATH="$OPTARG"
@@ -116,6 +116,30 @@ if [[ $docker_not_running -eq 1 ]]; then
     fi
 fi
 
+resolve_docker_socket_path() {
+    local docker_host="${DOCKER_HOST:-}"
+
+    if [ -z "$docker_host" ] && [[ "$(uname -s)" == "Linux" ]]; then
+        docker_host=$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null || true)
+    fi
+
+    if [[ "$docker_host" == unix://* ]]; then
+        DOCKER_SOCKET_PATH="${docker_host#unix://}"
+    elif [[ "$(uname -s)" == "Linux" && -S "/run/user/$(id -u)/docker.sock" && ! -S "/var/run/docker.sock" ]]; then
+        DOCKER_SOCKET_PATH="/run/user/$(id -u)/docker.sock"
+    else
+        DOCKER_SOCKET_PATH="/var/run/docker.sock"
+    fi
+
+    if [ ! -S "$DOCKER_SOCKET_PATH" ]; then
+        echo "⚠️ ${yellow}Docker socket not found at ${DOCKER_SOCKET_PATH}. Traefik may fail to access Docker events.${reset}"
+    else
+        echo "🐳 Using Docker socket: ${green}${DOCKER_SOCKET_PATH}${reset}"
+    fi
+}
+
+resolve_docker_socket_path
+
 mkdir -p swanlab && cd swanlab
 
 # Select whether to use this configuration
@@ -198,7 +222,7 @@ services:
     ports:
       - "${EXPOSE_PORT}:80"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - ${DOCKER_SOCKET_PATH}:/var/run/docker.sock
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "0.0.0.0:8080/ping"]
       interval: 10s

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -118,15 +118,16 @@ fi
 
 resolve_docker_socket_path() {
     local docker_host="${DOCKER_HOST:-}"
+    local rootless_socket="/run/user/$(id -u)/docker.sock"
 
-    if [ -z "$docker_host" ] && [[ "$(uname -s)" == "Linux" ]]; then
+    if [ -z "$docker_host" ]; then
         docker_host=$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null || true)
     fi
 
     if [[ "$docker_host" == unix://* ]]; then
         DOCKER_SOCKET_PATH="${docker_host#unix://}"
-    elif [[ "$(uname -s)" == "Linux" && -S "/run/user/$(id -u)/docker.sock" && ! -S "/var/run/docker.sock" ]]; then
-        DOCKER_SOCKET_PATH="/run/user/$(id -u)/docker.sock"
+    elif [[ -S "$rootless_socket" ]]; then
+        DOCKER_SOCKET_PATH="$rootless_socket"
     else
         DOCKER_SOCKET_PATH="/var/run/docker.sock"
     fi

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -19,7 +19,7 @@ EXPOSE_PORT=8000
 # shell flag: -s, if -s is added, no manual input is required
 SKIP_INPUT=0
 
-while getopts ":d:p:" opt; do
+while getopts ":d:p:s" opt; do
   case ${opt} in
     d )
       DATA_PATH="$OPTARG"
@@ -116,6 +116,30 @@ if [[ $docker_not_running -eq 1 ]]; then
     fi
 fi
 
+resolve_docker_socket_path() {
+    local docker_host="${DOCKER_HOST:-}"
+
+    if [ -z "$docker_host" ] && [[ "$(uname -s)" == "Linux" ]]; then
+        docker_host=$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null || true)
+    fi
+
+    if [[ "$docker_host" == unix://* ]]; then
+        DOCKER_SOCKET_PATH="${docker_host#unix://}"
+    elif [[ "$(uname -s)" == "Linux" && -S "/run/user/$(id -u)/docker.sock" && ! -S "/var/run/docker.sock" ]]; then
+        DOCKER_SOCKET_PATH="/run/user/$(id -u)/docker.sock"
+    else
+        DOCKER_SOCKET_PATH="/var/run/docker.sock"
+    fi
+
+    if [ ! -S "$DOCKER_SOCKET_PATH" ]; then
+        echo "⚠️ ${yellow}Docker socket not found at ${DOCKER_SOCKET_PATH}. Traefik may fail to access Docker events.${reset}"
+    else
+        echo "🐳 Using Docker socket: ${green}${DOCKER_SOCKET_PATH}${reset}"
+    fi
+}
+
+resolve_docker_socket_path
+
 mkdir -p swanlab && cd swanlab
 
 # Select whether to use this configuration
@@ -196,7 +220,7 @@ services:
     ports:
       - "${EXPOSE_PORT}:80"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - ${DOCKER_SOCKET_PATH}:/var/run/docker.sock
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "0.0.0.0:8080/ping"]
       interval: 10s


### PR DESCRIPTION
## 概要

这个 PR 为所有 Docker 安装入口补充 rootless Docker socket 支持：

- `docker/install.sh`
- `docker/install-dockerhub.sh`
- `docker/install-nowsl.sh`

此前安装脚本生成的 Compose 文件会把 Traefik 的 Docker socket 固定挂载为 rootful Docker 默认路径：

```yaml
/var/run/docker.sock:/var/run/docker.sock
```

这会导致 rootless Docker 环境不可用，因为 rootless Docker 的 daemon socket 通常通过 `DOCKER_HOST` 暴露，例如：

```bash
DOCKER_HOST=unix:///run/user/<uid>/docker.sock
```

## 验证

已在`Debian13`服务器的`rootless Docker`上完成验证
close #104 
