### PR TITLE
ci: install script tests

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -1,0 +1,109 @@
+name: Install scripts tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "docker/install.sh"
+      - "docker/install-dockerhub.sh"
+      - "scripts/run-install-smoke.sh"
+      - ".github/workflows/install-smoke.yml"
+
+jobs:
+  ubuntu-rootful:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      SWANLAB_EXPECTED_SOCKET: /var/run/docker.sock
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run install.sh on Ubuntu rootful Docker
+        run: |
+          chmod +x docker/*.sh scripts/*.sh
+          scripts/run-install-smoke.sh
+
+      - name: Dump Docker logs on failure
+        if: failure()
+        run: |
+          if [ -f /tmp/dockerd.log ]; then
+            tail -n 300 /tmp/dockerd.log
+          fi
+
+  wsl2-rootful:
+    runs-on: windows-2022
+    timeout-minutes: 45
+    env:
+      SWANLAB_EXPECTED_SOCKET: /var/run/docker.sock
+
+    defaults:
+      run:
+        shell: wsl-bash {0}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup WSL2 Ubuntu
+        uses: Vampire/setup-wsl@v7
+        with:
+          distribution: Ubuntu-24.04
+          wsl-version: 2
+          update: "true"
+          wsl-shell-user: root
+
+      - name: Install Docker Engine in WSL2
+        run: |
+          apt-get update
+          apt-get install -y ca-certificates curl iptables
+          curl -fsSL https://get.docker.com | sh
+
+      - name: Run install.sh in WSL2 rootful Docker
+        run: |
+          sed -i 's/\r$//' docker/*.sh scripts/*.sh
+          chmod +x docker/*.sh scripts/*.sh
+          scripts/run-install-smoke.sh
+
+      - name: Dump Docker logs on failure
+        if: failure()
+        run: |
+          if [ -f /tmp/dockerd.log ]; then
+            tail -n 300 /tmp/dockerd.log
+          fi
+
+  ubuntu-rootless:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      SWANLAB_INSTALL_SCRIPT: install-dockerhub.sh
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install rootless Docker dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl dbus-user-session fuse-overlayfs slirp4netns uidmap
+          curl -fsSL https://get.docker.com | sudo sh
+
+      - name: Setup rootless Docker
+        run: |
+          dockerd-rootless-setuptool.sh install --force
+          systemctl --user start docker
+          echo "DOCKER_HOST=unix:///run/user/$(id -u)/docker.sock" >> "${GITHUB_ENV}"
+          echo "SWANLAB_EXPECTED_SOCKET=/run/user/$(id -u)/docker.sock" >> "${GITHUB_ENV}"
+
+      - name: Run install.sh on Ubuntu rootless Docker
+        run: |
+          chmod +x docker/*.sh scripts/*.sh
+          scripts/run-install-smoke.sh
+
+      - name: Dump Docker logs on failure
+        if: failure()
+        run: |
+          if [ -f /tmp/dockerd.log ]; then
+            tail -n 300 /tmp/dockerd.log
+          fi

--- a/scripts/run-install-smoke.sh
+++ b/scripts/run-install-smoke.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALL_SCRIPT_NAME="${SWANLAB_INSTALL_SCRIPT:-install.sh}"
+INSTALL_SCRIPT="${REPO_ROOT}/docker/${INSTALL_SCRIPT_NAME}"
+WORK_DIR="${SWANLAB_TEST_WORK_DIR:-/tmp/swanlab-install-action-work}"
+INSTALL_DIR="${WORK_DIR}/swanlab"
+DATA_DIR="${SWANLAB_TEST_DATA_DIR:-/tmp/swanlab-install-action-data}"
+PORT="${SWANLAB_TEST_PORT:-18000}"
+EXPECTED_SOCKET="${SWANLAB_EXPECTED_SOCKET:-/var/run/docker.sock}"
+
+wait_for_docker() {
+  for _ in {1..60}; do
+    if docker info >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "Docker daemon did not become ready" >&2
+  if [ -f /tmp/dockerd.log ]; then
+    tail -n 200 /tmp/dockerd.log >&2 || true
+  fi
+  return 1
+}
+
+cleanup() {
+  if [ -f "${INSTALL_DIR}/docker-compose.yaml" ]; then
+    docker compose -f "${INSTALL_DIR}/docker-compose.yaml" down -v || true
+  fi
+  if [ -d "${DATA_DIR}" ] && docker info >/dev/null 2>&1; then
+    docker run --rm -v "${DATA_DIR}:/data" alpine:3.20 sh -c \
+      "find /data -mindepth 1 -maxdepth 1 -exec rm -rf {} +" || true
+  fi
+  sudo rm -rf "${WORK_DIR}" "${DATA_DIR}" 2>/dev/null || rm -rf "${WORK_DIR}" "${DATA_DIR}" 2>/dev/null || true
+}
+
+trap cleanup EXIT
+
+bash -n "${INSTALL_SCRIPT}"
+
+if ! docker info >/dev/null 2>&1; then
+  nohup dockerd --host=unix:///var/run/docker.sock >/tmp/dockerd.log 2>&1 &
+fi
+
+wait_for_docker
+docker compose version
+
+cleanup
+mkdir -p "${WORK_DIR}"
+(cd "${WORK_DIR}" && bash "${INSTALL_SCRIPT}" -d "${DATA_DIR}" -p "${PORT}" -s)
+
+grep -n "${EXPECTED_SOCKET}:/var/run/docker.sock" "${INSTALL_DIR}/docker-compose.yaml"
+docker compose -f "${INSTALL_DIR}/docker-compose.yaml" ps

--- a/scripts/run-install-smoke.sh
+++ b/scripts/run-install-smoke.sh
@@ -40,7 +40,7 @@ trap cleanup EXIT
 
 bash -n "${INSTALL_SCRIPT}"
 
-if ! docker info >/dev/null 2>&1; then
+if ! docker info >/dev/null 2>&1 && [ -z "${DOCKER_HOST:-}" ] && [ "$(id -u)" -eq 0 ]; then
   nohup dockerd --host=unix:///var/run/docker.sock >/tmp/dockerd.log 2>&1 &
 fi
 


### PR DESCRIPTION
## 概要

为 self-hosted 安装脚本增加 GitHub Actions smoke test。

## 改动

- 新增 `install-smoke.yml` workflow，包含 3 个并行 job：
  - Ubuntu rootful Docker
  - WSL2 Ubuntu rootful Docker
  - Ubuntu rootless Docker
- 新增 `scripts/run-install-smoke.sh`，作为共享 CI 测试 runner。
- 在 rootful Ubuntu 和 WSL2 环境下测试 `docker/install.sh`。
- 在 rootless Ubuntu 环境下测试 `docker/install-dockerhub.sh`。
- 校验生成的 Compose 文件是否挂载了预期的 Docker socket。

## 测试结果
<img width="705" height="454" alt="截屏2026-05-20 14 29 20" src="https://github.com/user-attachments/assets/de58984d-cc23-4a37-8630-9c951ee2093e" />
